### PR TITLE
Updated README to use the correct package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@
 
 ---
 ### Index
-- [About](#about)
-- [Requirements](#requirements)
+- [Introduction](#introduction)
+- [Installation](#installation)
 - [Composer Installation](#composer-installation)
-- [Requirements](#requirements)
-- [Example](#example)
+- [Usage](#usage)
+- [Validation](#validation)
+- [Conclusion](#conclusion)
 - [Contribute](#contribute)
 - [Versioning](#versioning)
 - [Additional information](#additional-information)

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ To install the Laravel Buckaroo Wrapper, you can use Composer by running the fol
 
 By far the easiest way to install the Laravel Buckaroo client is to require it with [Composer](http://getcomposer.org/doc/00-intro.md).
 
-    $ composer require buckaroo/laravel-buckaroo:^1.0
+    $ composer require buckaroo/laravel:^1.0
 
     {
         "require": {
-            "buckaroo/laravel-laravel": "^1.0"
+            "buckaroo/laravel": "^1.0"
         }
     }
 


### PR DESCRIPTION
# The issue
During the installation process of the Laravel wrapper, an issue was encountered where the package could not be installed. Upon further investigation, it was discovered that the discrepancy was due to an incorrect package name listed in the documentation.

This pull request addresses the issue by updating the README file to reflect the correct package name, ensuring future installations proceed without similar problems.

## Changes Made
Corrected the package name in the README documentation.