### PR TITLE
Refactor request data handling to standardize with $this->all() in FormRequest

### DIFF
--- a/src/Http/Requests/ReplyHandlerRequest.php
+++ b/src/Http/Requests/ReplyHandlerRequest.php
@@ -30,7 +30,7 @@ class ReplyHandlerRequest extends FormRequest
     protected function validateBody()
     {
         return Buckaroo::api()->validateBody(
-            (!empty($_POST)) ? $_POST : $this->getContent(),
+            $this->all(),
             $this->header('Authorization') ?? '',
             route('buckaroo.push')
         );


### PR DESCRIPTION
### Changes
- Replaced `(!empty($_POST)) ? $_POST : $this->getContent()` with `$this->all()`
- `$this->all()` provides a consistent, parsed associative array for all request types (JSON, form-data, query parameters), ensuring that the request data is properly handled by Laravel's internal request processing.
