### PR TITLE
BTI-834 Use raw request body for signature validation

### DIFF
--- a/src/BuckarooServiceProvider.php
+++ b/src/BuckarooServiceProvider.php
@@ -27,7 +27,8 @@ class BuckarooServiceProvider extends ServiceProvider
         $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
         $this->mergeConfigFrom(__DIR__ . '/../config/buckaroo.php', 'buckaroo');
 
-        TrimStrings::skipWhen(fn ($request) => $request->is(config('buckaroo.routes.prefix', 'buckaroo') . '/push'));
+        $prefix = config('buckaroo.routes.prefix', 'buckaroo');
+        TrimStrings::skipWhen(fn ($request) => $request->is($prefix . '/push', $prefix . '/return'));
     }
 
     protected function configurePublishing()

--- a/src/BuckarooServiceProvider.php
+++ b/src/BuckarooServiceProvider.php
@@ -6,6 +6,7 @@ use Buckaroo\Laravel\Console\PublishCommand;
 use Buckaroo\Laravel\Wrappers\BuckarooClient;
 use Buckaroo\Laravel\Wrappers\BuckarooManager;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Foundation\Http\Middleware\TrimStrings;
 use Illuminate\Support\ServiceProvider;
 
 class BuckarooServiceProvider extends ServiceProvider
@@ -25,6 +26,8 @@ class BuckarooServiceProvider extends ServiceProvider
 
         $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
         $this->mergeConfigFrom(__DIR__ . '/../config/buckaroo.php', 'buckaroo');
+
+        TrimStrings::skipWhen(fn ($request) => $request->is(config('buckaroo.routes.prefix', 'buckaroo') . '/push'));
     }
 
     protected function configurePublishing()

--- a/src/Http/Requests/ReplyHandlerRequest.php
+++ b/src/Http/Requests/ReplyHandlerRequest.php
@@ -16,7 +16,7 @@ class ReplyHandlerRequest extends FormRequest
     public function authorize(): bool
     {
         /* @var ResponseParserInterface $data */
-        $this->data = ResponseParser::make($this->all());
+        $this->data = ResponseParser::make($this->getRawData());
 
         if (!$this->validateBody()) {
             $this->message = 'Invalid signature';
@@ -25,6 +25,28 @@ class ReplyHandlerRequest extends FormRequest
         }
 
         return true;
+    }
+
+    /**
+     * Get raw POST data preserving trailing spaces for signature verification.
+     */
+    protected function getRawData(): array
+    {
+        $rawContent = $this->getContent();
+
+        if (!$rawContent) {
+            return $this->all();
+        }
+
+        if ($this->isJson()) {
+            $decoded = json_decode($rawContent, true);
+
+            return is_array($decoded) ? $decoded : $this->all();
+        }
+
+        parse_str($rawContent, $parsed);
+
+        return !empty($parsed) ? $parsed : $this->all();
     }
 
     protected function validateBody()

--- a/src/Http/Requests/ReplyHandlerRequest.php
+++ b/src/Http/Requests/ReplyHandlerRequest.php
@@ -16,7 +16,7 @@ class ReplyHandlerRequest extends FormRequest
     public function authorize(): bool
     {
         /* @var ResponseParserInterface $data */
-        $this->data = ResponseParser::make($this->getRawData());
+        $this->data = ResponseParser::make($this->all());
 
         if (!$this->validateBody()) {
             $this->message = 'Invalid signature';
@@ -25,28 +25,6 @@ class ReplyHandlerRequest extends FormRequest
         }
 
         return true;
-    }
-
-    /**
-     * Get raw POST data preserving trailing spaces for signature verification.
-     */
-    protected function getRawData(): array
-    {
-        $rawContent = $this->getContent();
-
-        if (!$rawContent) {
-            return $this->all();
-        }
-
-        if ($this->isJson()) {
-            $decoded = json_decode($rawContent, true);
-
-            return is_array($decoded) ? $decoded : $this->all();
-        }
-
-        parse_str($rawContent, $parsed);
-
-        return !empty($parsed) ? $parsed : $this->all();
     }
 
     protected function validateBody()


### PR DESCRIPTION
Skipped global TrimStrings middleware on push and return routes to prevent TrimStrings middleware from removing trailing spaces from request values and invalidating push signatures.