### PR TITLE
Laravel 13 support: install and green on PHPUnit 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
         "illuminate/support": "^9.0|^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
-        "graham-campbell/testbench": "^5.0",
-        "phpunit/phpunit": "^9.5|^10.0|^11.0",
+        "graham-campbell/testbench": "^5.0|^6.0",
+        "phpunit/phpunit": "^9.5|^10.0|^11.0|^12.0",
         "friendsofphp/php-cs-fixer": "^3.13",
         "vlucas/phpdotenv": "^5.5",
         "laravel/pint": "^1.16"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,11 +9,11 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-    <coverage processUncoveredFiles="true">
+    <source>
         <include>
-            <directory suffix=".php">./app</directory>
+            <directory suffix=".php">./src</directory>
         </include>
-    </coverage>
+    </source>
     <php>
         <env name="APP_ENV" value="testing"/>
         <env name="BCRYPT_ROUNDS" value="4"/>

--- a/tests/ConfirmingCredentialsTest.php
+++ b/tests/ConfirmingCredentialsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  *
  *  * NOTICE OF LICENSE
@@ -22,17 +23,21 @@
 
 namespace Buckaroo\Laravel\Tests;
 
+use Buckaroo\BuckarooClient;
+
 class ConfirmingCredentialsTest extends TestCase
 {
-    /**
-     * @return void
-     *
-     * @test
-     */
-    public function it_tests_given_credentials()
+    public function test_it_confirms_given_credentials()
     {
-        $response = $this->buckaroo->confirmCredential();
+        $websiteKey = $_ENV['BPE_WEBSITE_KEY'] ?? null;
+        $secretKey = $_ENV['BPE_SECRET_KEY'] ?? null;
 
-        $this->assertTrue($response);
+        if (empty($websiteKey) || empty($secretKey)) {
+            $this->markTestSkipped('Buckaroo credentials are not configured.');
+        }
+
+        $buckaroo = new BuckarooClient($websiteKey, $secretKey);
+
+        $this->assertTrue($buckaroo->confirmCredential());
     }
 }

--- a/tests/ResponseParserCompatTest.php
+++ b/tests/ResponseParserCompatTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Buckaroo\Laravel\Tests;
+
+use Buckaroo\Laravel\Handlers\FormDataParser;
+use Buckaroo\Laravel\Handlers\JsonParser;
+use Buckaroo\Laravel\Handlers\ResponseParser;
+
+class ResponseParserCompatTest extends TestCase
+{
+    public function test_make_routes_brq_payloads_to_the_form_data_parser()
+    {
+        $parser = ResponseParser::make(['brq_statuscode' => '190', 'brq_amount' => '10.00']);
+
+        $this->assertInstanceOf(FormDataParser::class, $parser);
+    }
+
+    public function test_make_routes_json_payloads_to_the_json_parser()
+    {
+        $parser = ResponseParser::make(['Transaction' => ['Status' => ['Code' => ['Code' => 190]]]]);
+
+        $this->assertInstanceOf(JsonParser::class, $parser);
+    }
+
+    public function test_make_stays_compatible_with_the_collection_signature()
+    {
+        $parser = ResponseParser::make(['brq_statuscode' => '190'], 'ignored', 'args');
+
+        $this->assertInstanceOf(FormDataParser::class, $parser);
+        $this->assertSame(['brq_statuscode' => '190'], $parser->getOriginalItems());
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,19 +2,21 @@
 
 namespace Buckaroo\Laravel\Tests;
 
-use Buckaroo\BuckarooClient;
+use Buckaroo\Laravel\BuckarooServiceProvider;
 use Dotenv\Dotenv;
 use GrahamCampbell\TestBench\AbstractPackageTestCase;
 
 abstract class TestCase extends AbstractPackageTestCase
 {
-    public function __construct()
+    protected function setUp(): void
     {
-        $dotenv = Dotenv::createImmutable(getcwd());
-        $dotenv->load();
+        parent::setUp();
 
-        $this->buckaroo = new BuckarooClient($_ENV['BPE_WEBSITE_KEY'], $_ENV['BPE_SECRET_KEY']);
+        Dotenv::createImmutable(getcwd())->safeLoad();
+    }
 
-        parent::__construct();
+    protected static function getServiceProviderClass(): string
+    {
+        return BuckarooServiceProvider::class;
     }
 }


### PR DESCRIPTION
Makes the package actually installable and testable on Laravel 13, not just allowed by the composer constraints.

PR #33 added `^13.0` to the framework constraints but left the dev toolchain behind, so the test suite could not resolve or run against Laravel 13. This finishes that.

Includes the `ResponseParser::make()` signature fix from #37 (needed for the L13 `Collection::make($items = [], ...$args)` signature), then adds the rest:

- widen dev deps (additive, keeps L12): `graham-campbell/testbench` `^5.0|^6.0`, `phpunit/phpunit` adds `^12.0`
- `tests/TestCase.php`: the zero-arg `__construct()` fatals under PHPUnit 12 (constructor now requires `$name`); moved setup into `setUp()` and registered the service provider so the app boots
- `phpunit.xml`: migrated the coverage block to the PHPUnit 10+ `source` schema and pointed it at `./src` (the old `./app` path does not exist)
- the live credentials test now skips when `BPE_*` keys are absent instead of erroring
- added compat tests covering the `ResponseParser::make()` routing and the variadic signature under the real Laravel 13 Collection

Verified locally:

- composer resolves on Laravel 13.18 (orchestra/testbench 11, graham-campbell/testbench 6.3, PHPUnit 12.5), no advisories
- Laravel 12 still resolves cleanly
- suite green on L13 / PHPUnit 12: 4 tests, 3 pass, 1 skip (live API)
- pint clean on the changed files

Not covered: the live Buckaroo API call (no creds in CI), and PHP < 8.5 (tested on 8.5 only). The php floor is left at `>=8.0` on purpose so the L9-12 runtime support the package still advertises is not dropped.

If #37 merges first this rebases cleanly (its commit is included here). Relates to #36, #37, #33.
