### PR TITLE
v2.1.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
         "illuminate/support": "^9.0|^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
-        "graham-campbell/testbench": "^5.0",
-        "phpunit/phpunit": "^9.5|^10.0|^11.0",
+        "graham-campbell/testbench": "^5.0|^6.0",
+        "phpunit/phpunit": "^9.5|^10.0|^11.0|^12.0",
         "friendsofphp/php-cs-fixer": "^3.13",
         "vlucas/phpdotenv": "^5.5",
         "laravel/pint": "^1.16"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,11 +9,11 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-    <coverage processUncoveredFiles="true">
+    <source>
         <include>
-            <directory suffix=".php">./app</directory>
+            <directory suffix=".php">./src</directory>
         </include>
-    </coverage>
+    </source>
     <php>
         <env name="APP_ENV" value="testing"/>
         <env name="BCRYPT_ROUNDS" value="4"/>

--- a/tests/ConfirmingCredentialsTest.php
+++ b/tests/ConfirmingCredentialsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  *
  *  * NOTICE OF LICENSE
@@ -22,17 +23,21 @@
 
 namespace Buckaroo\Laravel\Tests;
 
+use Buckaroo\BuckarooClient;
+
 class ConfirmingCredentialsTest extends TestCase
 {
-    /**
-     * @return void
-     *
-     * @test
-     */
-    public function it_tests_given_credentials()
+    public function test_it_confirms_given_credentials()
     {
-        $response = $this->buckaroo->confirmCredential();
+        $websiteKey = $_ENV['BPE_WEBSITE_KEY'] ?? null;
+        $secretKey = $_ENV['BPE_SECRET_KEY'] ?? null;
 
-        $this->assertTrue($response);
+        if (empty($websiteKey) || empty($secretKey)) {
+            $this->markTestSkipped('Buckaroo credentials are not configured.');
+        }
+
+        $buckaroo = new BuckarooClient($websiteKey, $secretKey);
+
+        $this->assertTrue($buckaroo->confirmCredential());
     }
 }

--- a/tests/ResponseParserCompatTest.php
+++ b/tests/ResponseParserCompatTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Buckaroo\Laravel\Tests;
+
+use Buckaroo\Laravel\Handlers\FormDataParser;
+use Buckaroo\Laravel\Handlers\JsonParser;
+use Buckaroo\Laravel\Handlers\ResponseParser;
+
+class ResponseParserCompatTest extends TestCase
+{
+    public function test_make_routes_brq_payloads_to_the_form_data_parser()
+    {
+        $parser = ResponseParser::make(['brq_statuscode' => '190', 'brq_amount' => '10.00']);
+
+        $this->assertInstanceOf(FormDataParser::class, $parser);
+    }
+
+    public function test_make_routes_json_payloads_to_the_json_parser()
+    {
+        $parser = ResponseParser::make(['Transaction' => ['Status' => ['Code' => ['Code' => 190]]]]);
+
+        $this->assertInstanceOf(JsonParser::class, $parser);
+    }
+
+    public function test_make_stays_compatible_with_the_collection_signature()
+    {
+        $parser = ResponseParser::make(['brq_statuscode' => '190'], 'ignored', 'args');
+
+        $this->assertInstanceOf(FormDataParser::class, $parser);
+        $this->assertSame(['brq_statuscode' => '190'], $parser->getOriginalItems());
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,19 +2,21 @@
 
 namespace Buckaroo\Laravel\Tests;
 
-use Buckaroo\BuckarooClient;
+use Buckaroo\Laravel\BuckarooServiceProvider;
 use Dotenv\Dotenv;
 use GrahamCampbell\TestBench\AbstractPackageTestCase;
 
 abstract class TestCase extends AbstractPackageTestCase
 {
-    public function __construct()
+    protected function setUp(): void
     {
-        $dotenv = Dotenv::createImmutable(getcwd());
-        $dotenv->load();
+        parent::setUp();
 
-        $this->buckaroo = new BuckarooClient($_ENV['BPE_WEBSITE_KEY'], $_ENV['BPE_SECRET_KEY']);
+        Dotenv::createImmutable(getcwd())->safeLoad();
+    }
 
-        parent::__construct();
+    protected static function getServiceProviderClass(): string
+    {
+        return BuckarooServiceProvider::class;
     }
 }


### PR DESCRIPTION
- Make the test suite installable and green on Laravel 13 / PHPUnit 12
- Add `graham-campbell/testbench ^6.0` and `phpunit/phpunit ^12.0` to dev dependencies
- Add `ResponseParserCompatTest` for signature-validation compatibility across Laravel versions